### PR TITLE
defaultContentOffsetX are not necessarily screen width

### DIFF
--- a/Pod/Classes/TabPageViewController.swift
+++ b/Pod/Classes/TabPageViewController.swift
@@ -25,7 +25,9 @@ public class TabPageViewController: UIPageViewController {
     }
     private var beforeIndex: Int = 0
     private var tabItemsCount = 0
-    private var defaultContentOffsetX: CGFloat = UIScreen.mainScreen().bounds.width
+    private var defaultContentOffsetX: CGFloat {
+        return self.view.bounds.width
+    }
     private var shouldScrollCurrentBar: Bool = true
     lazy private var tabView: TabView = self.configuredTabView()
 


### PR DESCRIPTION
Hi, @EndouMari.

I want to use this library in the width of several screen.

For example,
- Page Sheet
- Form Sheet, etc.

However, `defaultContentOffsetX` is width of the screen.

Do you have any good ideas?
