### PR TITLE
Add setTabItemTitle

### DIFF
--- a/Demo/TabPageViewControllerDemo/ViewController.swift
+++ b/Demo/TabPageViewControllerDemo/ViewController.swift
@@ -55,5 +55,8 @@ class ViewController: UIViewController {
         option.tabMargin = 30.0
         tc.option = option
         navigationController?.pushViewController(tc, animated: true)
+
+        // Change tab title
+        tc.setTabItemTitle("Mon.(*)", at: 0)
     }
 }

--- a/Sources/TabPageViewController.swift
+++ b/Sources/TabPageViewController.swift
@@ -29,7 +29,7 @@ open class TabPageViewController: UIPageViewController {
         return self.view.bounds.width
     }
     fileprivate var shouldScrollCurrentBar: Bool = true
-    lazy fileprivate var tabView: TabView = self.configuredTabView()
+    lazy open var tabView: TabView = self.configuredTabView()
     fileprivate var statusView: UIView?
     fileprivate var statusViewHeightConstraint: NSLayoutConstraint?
     fileprivate var tabBarTopConstraint: NSLayoutConstraint?

--- a/Sources/TabPageViewController.swift
+++ b/Sources/TabPageViewController.swift
@@ -313,6 +313,16 @@ extension TabPageViewController: UIPageViewControllerDataSource {
     public func pageViewController(_ pageViewController: UIPageViewController, viewControllerBefore viewController: UIViewController) -> UIViewController? {
         return nextViewController(viewController, isAfter: false)
     }
+
+    public func setTabItemTitle(_ title: String, at: Int) {
+        guard 0..<tabItems.count ~= at else {
+            print("Specified `at` argument was out of range")
+            return
+        }
+
+        tabItems[at].title = title
+        tabView.pageTabItems[at] = tabItems[at].title
+    }
 }
 
 

--- a/Sources/TabView.swift
+++ b/Sources/TabView.swift
@@ -15,6 +15,12 @@ open class TabView: UIView {
         didSet {
             pageTabItemsCount = pageTabItems.count
             beforeIndex = pageTabItems.count
+
+            // pageTabItems を変更したらリロード
+            if let c = collectionView {
+                print("Reload collectionView")
+                c.reloadData()
+            }
         }
     }
     var layouted: Bool = false

--- a/Sources/TabView.swift
+++ b/Sources/TabView.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-internal class TabView: UIView {
+open class TabView: UIView {
 
     var pageItemPressedBlock: ((_ index: Int, _ direction: UIPageViewControllerNavigationDirection) -> Void)?
     var pageTabItems: [String] = [] {
@@ -117,7 +117,7 @@ internal class TabView: UIView {
         bottomBarViewHeightConstraint.constant = 1.0 / UIScreen.main.scale
     }
 
-    required internal init?(coder aDecoder: NSCoder) {
+    required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
 }
@@ -287,11 +287,11 @@ extension TabView {
 
 extension TabView: UICollectionViewDataSource {
 
-    internal func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return isInfinity ? pageTabItemsCount * 3 : pageTabItemsCount
     }
 
-    internal func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+    public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: TabCollectionCell.cellIdentifier(), for: indexPath) as! TabCollectionCell
         configureCell(cell, indexPath: indexPath)
         return cell
@@ -325,7 +325,7 @@ extension TabView: UICollectionViewDataSource {
         }
     }
 
-    func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+    public func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
         // FIXME: Tabs are not displayed when processing is performed during introduction display
         if let cell = cell as? TabCollectionCell, layouted {
             let fixedIndex = isInfinity ? indexPath.item % pageTabItemsCount : indexPath.item
@@ -339,7 +339,7 @@ extension TabView: UICollectionViewDataSource {
 
 extension TabView: UICollectionViewDelegate {
 
-    internal func scrollViewDidScroll(_ scrollView: UIScrollView) {
+    public func scrollViewDidScroll(_ scrollView: UIScrollView) {
         if scrollView.isDragging {
             currentBarView.isHidden = true
             let indexPath = IndexPath(item: currentIndex, section: 0)
@@ -362,7 +362,7 @@ extension TabView: UICollectionViewDelegate {
 
     }
 
-    internal func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
+    public func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
         // Accept the touch event because animation is complete
         updateCollectionViewUserInteractionEnabled(true)
 
@@ -384,7 +384,7 @@ extension TabView: UICollectionViewDelegate {
 
 extension TabView: UICollectionViewDelegateFlowLayout {
 
-    internal func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+    public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
 
         if let size = cachedCellSizes[indexPath] {
             return size
@@ -398,11 +398,11 @@ extension TabView: UICollectionViewDelegateFlowLayout {
         return size
     }
 
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
+    public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
         return 0.0
     }
 
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+    public func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
         return 0.0
     }
 }


### PR DESCRIPTION
Sorry for writing in Japanese.

立て続けに失礼します。:)

TabPageViewController 表示後に、タブのタイトルを変更したく `setTabItemTitle(_ title: String, at: Int)` というメソッドを用意しました。

もともと当方のfork先で類似の変更をしていたのですが、本家に取り込んでいただいたほうがメリットがあると判断しましたので、問題がなければ取り込んでいただけないでしょうか。

すでの現状のコードで変更する方法があればご教示ください。

よろしくお願いします。

====

Automatic Translation using Google Translate

After displaying TabPageViewController, we have prepared a method called setTabItemTitle that allows you to change the title of the tab.

Originally we made a similar change at our fork destination, but we decided that it is beneficial to incorporate it in our headquarters, so if you do not have a problem, would you please incorporate it?

Please teach if there is any way to change with the current code.

Thank you.