### PR TITLE
add option to hide Scroll tab and Navigation bar separately

### DIFF
--- a/Demo/TabPageViewControllerDemo/ViewController.swift
+++ b/Demo/TabPageViewControllerDemo/ViewController.swift
@@ -31,6 +31,7 @@ class ViewController: UIViewController {
         option.tabWidth = view.frame.width / CGFloat(tc.tabItems.count)
         tc.option = option
         tc.option.hidesTabBarOnSwipe = true
+        tc.option.hidesNavigationBarOnSwipe = true
         navigationController?.pushViewController(tc, animated: true)
     }
 

--- a/Demo/TabPageViewControllerDemo/ViewController.swift
+++ b/Demo/TabPageViewControllerDemo/ViewController.swift
@@ -30,8 +30,7 @@ class ViewController: UIViewController {
         var option = TabPageOption()
         option.tabWidth = view.frame.width / CGFloat(tc.tabItems.count)
         tc.option = option
-        tc.option.hidesTabBarOnSwipe = true
-        tc.option.hidesNavigationBarOnSwipe = true
+        tc.option.hidesTopViewOnSwipe = .SrcollTabAndNavigationBar
         navigationController?.pushViewController(tc, animated: true)
     }
 

--- a/Demo/TabPageViewControllerDemo/ViewController.swift
+++ b/Demo/TabPageViewControllerDemo/ViewController.swift
@@ -29,8 +29,8 @@ class ViewController: UIViewController {
         tc.tabItems = [(vc1, "First"), (vc2, "Second")]
         var option = TabPageOption()
         option.tabWidth = view.frame.width / CGFloat(tc.tabItems.count)
+        option.hidesTopViewOnSwipeType = .all
         tc.option = option
-        tc.option.hidesTopViewOnSwipe = .SrcollTabAndNavigationBar
         navigationController?.pushViewController(tc, animated: true)
     }
 

--- a/Sources/TabPageOption.swift
+++ b/Sources/TabPageOption.swift
@@ -23,6 +23,7 @@ public struct TabPageOption {
     public var pageBackgoundColor: UIColor = UIColor.white
     public var isTranslucent: Bool = true
     public var hidesTabBarOnSwipe: Bool = false
+    public var hidesNavigationBarOnSwipe: Bool = false
 
     internal var tabBarAlpha: CGFloat {
         return isTranslucent ? 0.95 : 1.0

--- a/Sources/TabPageOption.swift
+++ b/Sources/TabPageOption.swift
@@ -8,6 +8,13 @@
 
 import UIKit
 
+public enum ScrollViewContent {
+    case None
+    case ScrollTabOnly
+    case NavigationBarOnly
+    case SrcollTabAndNavigationBar
+}
+
 public struct TabPageOption {
 
     public init() {}
@@ -22,8 +29,7 @@ public struct TabPageOption {
     public var tabBackgroundColor: UIColor = .white
     public var pageBackgoundColor: UIColor = UIColor.white
     public var isTranslucent: Bool = true
-    public var hidesTabBarOnSwipe: Bool = false
-    public var hidesNavigationBarOnSwipe: Bool = false
+    public var hidesTopViewOnSwipe: ScrollViewContent = .None
 
     internal var tabBarAlpha: CGFloat {
         return isTranslucent ? 0.95 : 1.0

--- a/Sources/TabPageOption.swift
+++ b/Sources/TabPageOption.swift
@@ -8,11 +8,11 @@
 
 import UIKit
 
-public enum ScrollViewContent {
-    case None
-    case ScrollTabOnly
-    case NavigationBarOnly
-    case SrcollTabAndNavigationBar
+public enum HidesTopContentsOnSwipeType {
+    case none
+    case tabBar
+    case navigationBar
+    case all
 }
 
 public struct TabPageOption {
@@ -29,7 +29,7 @@ public struct TabPageOption {
     public var tabBackgroundColor: UIColor = .white
     public var pageBackgoundColor: UIColor = UIColor.white
     public var isTranslucent: Bool = true
-    public var hidesTopViewOnSwipe: ScrollViewContent = .None
+    public var hidesTopViewOnSwipeType: HidesTopContentsOnSwipeType = .none
 
     internal var tabBarAlpha: CGFloat {
         return isTranslucent ? 0.95 : 1.0

--- a/Sources/TabPageViewController.swift
+++ b/Sources/TabPageViewController.swift
@@ -238,9 +238,14 @@ extension TabPageViewController {
 
         if option.hidesTabBarOnSwipe {
             updateTabBarOrigin(hidden: hidden)
+            if hidden == false {
+                showNavigationBar()
+            }
         }
-
-        navigationController.setNavigationBarHidden(hidden, animated: animated)
+        
+        if option.hidesNavigationBarOnSwipe && hidden {
+            navigationController.setNavigationBarHidden(true, animated: animated)
+        }
 
         if statusView == nil {
             setupStatusView()

--- a/Sources/TabPageViewController.swift
+++ b/Sources/TabPageViewController.swift
@@ -236,16 +236,16 @@ extension TabPageViewController {
     public func updateNavigationBarHidden(_ hidden: Bool, animated: Bool) {
         guard let navigationController = navigationController else { return }
 
-        switch option.hidesTopViewOnSwipe {
-        case .ScrollTabOnly:
+        switch option.hidesTopViewOnSwipeType {
+        case .tabBar:
             updateTabBarOrigin(hidden: hidden)
-        case .NavigationBarOnly:
+        case .navigationBar:
             if hidden {
                 navigationController.setNavigationBarHidden(true, animated: true)
             } else {
                 showNavigationBar()
             }
-        case .SrcollTabAndNavigationBar:
+        case .all:
             updateTabBarOrigin(hidden: hidden)
             if hidden {
                 navigationController.setNavigationBarHidden(true, animated: true)
@@ -267,7 +267,7 @@ extension TabPageViewController {
         guard navigationController.isNavigationBarHidden  else { return }
         guard let tabBarTopConstraint = tabBarTopConstraint else { return }
 
-        if option.hidesTopViewOnSwipe != .None {
+        if option.hidesTopViewOnSwipeType != .none {
             tabBarTopConstraint.constant = 0.0
             UIView.animate(withDuration: TimeInterval(UINavigationControllerHideShowBarDuration)) {
                 self.view.layoutIfNeeded()

--- a/Sources/TabPageViewController.swift
+++ b/Sources/TabPageViewController.swift
@@ -236,17 +236,25 @@ extension TabPageViewController {
     public func updateNavigationBarHidden(_ hidden: Bool, animated: Bool) {
         guard let navigationController = navigationController else { return }
 
-        if option.hidesTabBarOnSwipe {
+        switch option.hidesTopViewOnSwipe {
+        case .ScrollTabOnly:
             updateTabBarOrigin(hidden: hidden)
-            if hidden == false {
+        case .NavigationBarOnly:
+            if hidden {
+                navigationController.setNavigationBarHidden(true, animated: true)
+            } else {
                 showNavigationBar()
             }
+        case .SrcollTabAndNavigationBar:
+            updateTabBarOrigin(hidden: hidden)
+            if hidden {
+                navigationController.setNavigationBarHidden(true, animated: true)
+            } else {
+                showNavigationBar()
+            }
+        default:
+            break
         }
-        
-        if option.hidesNavigationBarOnSwipe && hidden {
-            navigationController.setNavigationBarHidden(true, animated: animated)
-        }
-
         if statusView == nil {
             setupStatusView()
         }
@@ -259,7 +267,7 @@ extension TabPageViewController {
         guard navigationController.isNavigationBarHidden  else { return }
         guard let tabBarTopConstraint = tabBarTopConstraint else { return }
 
-        if option.hidesTabBarOnSwipe {
+        if option.hidesTopViewOnSwipe != .None {
             tabBarTopConstraint.constant = 0.0
             UIView.animate(withDuration: TimeInterval(UINavigationControllerHideShowBarDuration)) {
                 self.view.layoutIfNeeded()


### PR DESCRIPTION
I forked your lib and fix this issue (Please look at what I commented at the bottom) [Hide Scroll tab view](https://github.com/EndouMari/TabPageViewController/issues/52)

I add another option in TabPageOption, named "hidesNavigationBarOnSwipe"
When hidesNavigationBarOnSwipe == true, navigation bar will be hidden.
When hidesNavigationBarOnSwipe == false, navigation bar will be shown.

So we can hide **Scroll tab** and **Navigation bar** separately. (Currently, when you drag to hide Scroll tab, Navigation bar is hidden too)