### PR TITLE
Changing `tabItemsCount` from stored property to computed property

### DIFF
--- a/Sources/TabPageViewController.swift
+++ b/Sources/TabPageViewController.swift
@@ -11,11 +11,7 @@ import UIKit
 open class TabPageViewController: UIPageViewController {
     open var isInfinity: Bool = false
     open var option: TabPageOption = TabPageOption()
-    open var tabItems: [(viewController: UIViewController, title: String)] = [] {
-        didSet {
-            tabItemsCount = tabItems.count
-        }
-    }
+    open var tabItems: [(viewController: UIViewController, title: String)] = []
 
     var currentIndex: Int? {
         guard let viewController = viewControllers?.first else {
@@ -24,7 +20,9 @@ open class TabPageViewController: UIPageViewController {
         return tabItems.map{ $0.viewController }.index(of: viewController)
     }
     fileprivate var beforeIndex: Int = 0
-    fileprivate var tabItemsCount = 0
+    fileprivate var tabItemsCount: Int {
+        return tabItems.count
+    }
     fileprivate var defaultContentOffsetX: CGFloat {
         return self.view.bounds.width
     }


### PR DESCRIPTION
I prefer to change `tabItemsCount` to computed property, because `didSet` does not fire when the property was **initialized**. So `open var tabItems: [(viewController: UIViewController, title: String)] = []` does not trigger `didSet`. `tabItemsCount` will have incorrect value if you make initial value nonempty.
