### PR TITLE
Fix bug occurs when tapping tabItem and swiping viewController at the same time

### DIFF
--- a/Sources/TabPageViewController.swift
+++ b/Sources/TabPageViewController.swift
@@ -78,7 +78,11 @@ open class TabPageViewController: UIPageViewController {
 public extension TabPageViewController {
 
     public func displayControllerWithIndex(_ index: Int, direction: UIPageViewControllerNavigationDirection, animated: Bool) {
+        guard beforeIndex != index else {
+            return
+        }
 
+        view.isUserInteractionEnabled = false
         beforeIndex = index
         shouldScrollCurrentBar = false
         let nextViewControllers: [UIViewController] = [tabItems[index].viewController]
@@ -86,6 +90,7 @@ public extension TabPageViewController {
         let completion: ((Bool) -> Void) = { [weak self] _ in
             self?.shouldScrollCurrentBar = true
             self?.beforeIndex = index
+            self?.view.isUserInteractionEnabled = true
         }
 
         setViewControllers(

--- a/Sources/TabPageViewController.swift
+++ b/Sources/TabPageViewController.swift
@@ -134,9 +134,10 @@ extension TabPageViewController {
 
     fileprivate func updateNavigationBar() {
         if let navigationBar = navigationController?.navigationBar {
-            navigationBar.shadowImage = UIImage()
-            navigationBar.setBackgroundImage(option.tabBackgroundImage, for: .default)
-            navigationBar.isTranslucent = option.isTranslucent
+          // Commented out to change navigationBar's color from outside of framework
+//            navigationBar.shadowImage = UIImage()
+//            navigationBar.setBackgroundImage(option.tabBackgroundImage, for: .default)
+//            navigationBar.isTranslucent = option.isTranslucent
         }
     }
 

--- a/Sources/TabPageViewController.swift
+++ b/Sources/TabPageViewController.swift
@@ -134,10 +134,9 @@ extension TabPageViewController {
 
     fileprivate func updateNavigationBar() {
         if let navigationBar = navigationController?.navigationBar {
-          // Commented out to change navigationBar's color from outside of framework
-//            navigationBar.shadowImage = UIImage()
-//            navigationBar.setBackgroundImage(option.tabBackgroundImage, for: .default)
-//            navigationBar.isTranslucent = option.isTranslucent
+            navigationBar.shadowImage = UIImage()
+            navigationBar.setBackgroundImage(option.tabBackgroundImage, for: .default)
+            navigationBar.isTranslucent = option.isTranslucent
         }
     }
 

--- a/Sources/TabPageViewController.swift
+++ b/Sources/TabPageViewController.swift
@@ -291,7 +291,7 @@ extension TabPageViewController {
 
 extension TabPageViewController: UIPageViewControllerDataSource {
 
-    fileprivate func nextViewController(_ viewController: UIViewController, isAfter: Bool) -> UIViewController? {
+    private func nextViewController(_ viewController: UIViewController, isAfter: Bool) -> UIViewController? {
 
         guard var index = tabItems.map({$0.viewController}).index(of: viewController) else {
             return nil


### PR DESCRIPTION
I had made a PR from incorrect branch so I recreated #67 🙏 

---

- Tap tabItem
- Swipe or tap viewController immediately (before tabItem's animation has finished)
- tabItem shows that **Blue** viewController is selected, but **Red** viewController is actually selected. (And after that, **Yellow** viewController disappears and be skipped)

<img src="https://cloud.githubusercontent.com/assets/3433324/26711577/43025e8a-479c-11e7-9847-77db9d334cdf.gif" width="300">

Sometimes app crashes but not every time.

```
2017-06-02 14:05:39.322094 TabPageViewControllerDemo[5856:1863363] *** Assertion failure in -[TabPageViewController.TabPageViewController queuingScrollView:didEndManualScroll:toRevealView:direction:animated:didFinish:didComplete:], /BuildRoot/Library/Caches/com.apple.xbs/Sources/UIKit/UIKit-3600.6.22/UIPageViewController.m:2083
2017-06-02 14:05:39.324377 TabPageViewControllerDemo[5856:1863363] *** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'No view controller managing visible view <UIView: 0x115f10400; frame = (0 0; 375 667); autoresize = W+H; layer = <CALayer: 0x17403f060>>'
*** First throw call stack:
(0x191e151b8 0x19084c55c 0x191e1508c 0x1928cd02c 0x1984d8ae0 0x1985aacbc 0x1985aaa14 0x1985a6b38 0x1985a97b8 0x1985acac4 0x1985accec 0x1985a7aa8 0x197fde050 0x197e73370 0x197e72eac 0x19506af24 0x19506add0 0x192082094 0x191daae50 0x191dc3218 0x191dc29cc 0x191dc04b0 0x191cee2b8 0x1937a2198 0x197d357fc 0x197d30534 0x10004b624 0x190cd15b8)
libc++abi.dylib: terminating with uncaught exception of type NSException
```

To prevent this bug, I set `tabPagerController.view.isUserInteractionEnabled` to `false` in `displayControllerWithIndex`, then set to `true` when animation has been completed.
This change works fine with my project currently.