### PR TITLE
Fixed weird animation in moveCurrentBarView when isInfinity is true

### DIFF
--- a/Sources/TabView.swift
+++ b/Sources/TabView.swift
@@ -221,7 +221,7 @@ extension TabView {
         } else {
             currentIndex = index
         }
-        let indexPath = IndexPath(item: index, section: 0)
+        let indexPath = IndexPath(item: currentIndex, section: 0)
         moveCurrentBarView(indexPath, animated: true, shouldScroll: true)
     }
 


### PR DESCRIPTION
I guess it's just a mistake. The following code is using `index`, but it should be `currentIndex`.
https://github.com/EndouMari/TabPageViewController/blob/master/Sources/TabView.swift#L224

The below is the exact part.
```
    /**
     Make the tapped cell the current if isInfinity is true

     - parameter index: Next IndexPath√
     */
    fileprivate func updateCurrentIndexForTap(_ index: Int) {
        deselectVisibleCells()

        if isInfinity && (index < pageTabItemsCount) || (index >= pageTabItemsCount * 2) {
            currentIndex = (index < pageTabItemsCount) ? index + pageTabItemsCount : index - pageTabItemsCount
            shouldScrollToItem = true
        } else {
            currentIndex = index
        }
        let indexPath = IndexPath(item: index, section: 0) // FIX: index -> currentIndex
        moveCurrentBarView(indexPath, animated: true, shouldScroll: true)
    }
```

As a result of this mistake, when `isInfinity` is true, it causes a weird animation when moving tab from the range of `pageTabItemsCount <= currentIndex < pageTabItemsCount * 2` to the range of `currentIndex < pageTabItemsCount && pageTabItemsCount * 2  <= currentIndex`.