### PR TITLE
Suppress `deprecated` warning

### DIFF
--- a/Sources/TabCollectionCell.swift
+++ b/Sources/TabCollectionCell.swift
@@ -47,7 +47,7 @@ class TabCollectionCell: UICollectionViewCell {
     }
 
     override func sizeThatFits(_ size: CGSize) -> CGSize {
-        if item.characters.count == 0 {
+        if item.isEmpy {
             return CGSize.zero
         }
 

--- a/Sources/TabCollectionCell.swift
+++ b/Sources/TabCollectionCell.swift
@@ -47,7 +47,7 @@ class TabCollectionCell: UICollectionViewCell {
     }
 
     override func sizeThatFits(_ size: CGSize) -> CGSize {
-        if item.isEmpy {
+        if item.isEmpty {
             return CGSize.zero
         }
 


### PR DESCRIPTION
Suppress `deprecated` warning. Here it's better to use isEmpty instead of
`count`.