### PR TITLE
Add support for lazy initialize

### DIFF
--- a/Demo/TabPageViewControllerDemo/InfiniteTabPageViewController.swift
+++ b/Demo/TabPageViewControllerDemo/InfiniteTabPageViewController.swift
@@ -23,9 +23,18 @@ class InfiniteTabPageViewController: TabPageViewController {
         vc4.view.backgroundColor = UIColor(red: 149/255, green: 252/255, blue: 197/255, alpha: 1.0)
         let vc5 = UIViewController()
         vc5.view.backgroundColor = UIColor(red: 252/255, green: 182/255, blue: 106/255, alpha: 1.0)
-        tabItems = [(vc1, "Mon."), (vc2, "Tue."), (vc3, "Wed."), (vc4, "Thu."), (vc5, "Fri.")]
-        isInfinity = true
-        option.currentColor = UIColor(red: 246/255, green: 175/255, blue: 32/255, alpha: 1.0)
+        tabItems = [
+            LazyTabItem(title: "Mon.") { vc1 },
+            LazyTabItem(title: "Tue.") { vc2 },
+            LazyTabItem(title: "Wed.") { vc3 },
+            LazyTabItem(title: "Thu.") { vc4 },
+            LazyTabItem(title: "Fri.") { vc5  },
+        ]
+        isInfinity = false
+        option.currentColor = UIColor.green
+        option.currentTextColor = UIColor.white
+        option.defaultColor = UIColor.white
+        option.defaultTextColor = UIColor.black
         option.tabMargin = 30.0
     }
 

--- a/Demo/TabPageViewControllerDemo/LimitedTabPageViewController.swift
+++ b/Demo/TabPageViewControllerDemo/LimitedTabPageViewController.swift
@@ -13,10 +13,20 @@ class LimitedTabPageViewController: TabPageViewController {
 
     override init() {
         super.init()
-        let vc1 = UIViewController()
-        vc1.view.backgroundColor = UIColor.white
-        let vc2 = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "ListViewController")
-        tabItems = [(vc1, "First"), (vc2, "Second")]
+//        let vc1 = UIViewController()
+//        vc1.view.backgroundColor = UIColor.white
+//        let vc2 = UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "ListViewController")
+        let tabItems = [
+            LazyTabItem(title: "First") {
+                let vc1 = UIViewController()
+                vc1.view.backgroundColor = UIColor.white
+                return vc1
+            },
+            LazyTabItem(title: "First") {
+                UIStoryboard(name: "Main", bundle: nil).instantiateViewController(withIdentifier: "ListViewController")
+            }
+        ]
+        self.tabItems = tabItems
         option.tabWidth = view.frame.width / CGFloat(tabItems.count)
         option.hidesTopViewOnSwipeType = .all
     }

--- a/Sources/TabCollectionCell.swift
+++ b/Sources/TabCollectionCell.swift
@@ -13,7 +13,7 @@ class TabCollectionCell: UICollectionViewCell {
     var tabItemButtonPressedBlock: ((Void) -> Void)?
     var option: TabPageOption = TabPageOption() {
         didSet {
-            currentBarViewHeightConstraint.constant = option.currentBarHeight
+            currentBarViewHeightConstraint.constant = option.tabHeight
         }
     }
     var item: String = "" {
@@ -84,12 +84,12 @@ extension TabCollectionCell {
     }
 
     func highlightTitle() {
-        itemLabel.textColor = option.currentColor
+        itemLabel.textColor = UIColor.blue
         itemLabel.font = UIFont.boldSystemFont(ofSize: option.fontSize)
     }
 
     func unHighlightTitle() {
-        itemLabel.textColor = option.defaultColor
+        itemLabel.textColor = UIColor.blue
         itemLabel.font = UIFont.systemFont(ofSize: option.fontSize)
     }
 }

--- a/Sources/TabCollectionCell.xib
+++ b/Sources/TabCollectionCell.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -18,6 +18,13 @@
                 <rect key="frame" x="0.0" y="0.0" width="151" height="50"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
+                    <view contentMode="scaleToFill" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UkM-Ly-JBr">
+                        <rect key="frame" x="0.0" y="0.0" width="151" height="50"/>
+                        <color key="backgroundColor" red="0.61176470588235299" green="0.91764705882352937" blue="0.97254901960784312" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="2" id="5V3-an-ChN"/>
+                        </constraints>
+                    </view>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IWJ-4f-Lz7">
                         <rect key="frame" x="59" y="17" width="33" height="16"/>
                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
@@ -31,13 +38,6 @@
                             <action selector="tabItemTouchUpInside:" destination="Njo-bq-MVA" eventType="touchUpInside" id="SX2-kA-L0U"/>
                         </connections>
                     </button>
-                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UkM-Ly-JBr">
-                        <rect key="frame" x="0.0" y="48" width="151" height="2"/>
-                        <color key="backgroundColor" red="0.61176470588235299" green="0.91764705882352937" blue="0.97254901960784312" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="2" id="5V3-an-ChN"/>
-                        </constraints>
-                    </view>
                 </subviews>
             </view>
             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>

--- a/Sources/TabItem.swift
+++ b/Sources/TabItem.swift
@@ -1,0 +1,48 @@
+//
+//  TabItem.swift
+//  TabPageViewController
+//
+//  Created by Yohta Watanave on 2018/03/05.
+//  Copyright © 2018年 Yohta Watanave. All rights reserved.
+//
+
+import UIKit
+
+public protocol TabItemProtocol {
+    var viewController: UIViewController { get }
+    var cacheViewController: UIViewController? { get }
+    var title: String { get }
+}
+
+public struct TabItem: TabItemProtocol {
+    public let viewController: UIViewController
+    public let title: String
+    public let cacheViewController: UIViewController?
+    
+    public init(viewController: UIViewController, title: String) {
+        self.viewController = viewController
+        self.title = title
+        self.cacheViewController = viewController
+    }
+    
+    public init(tuple: (UIViewController, String)) {
+        self.init(viewController: tuple.0, title: tuple.1)
+    }
+}
+
+public class LazyTabItem: TabItemProtocol {
+    public let title: String
+    public let createViewControllerBlock: ()->UIViewController
+    private(set) public weak var cacheViewController: UIViewController?
+    
+    init(title: String, createViewController: @escaping ()->UIViewController) {
+        self.title = title
+        self.createViewControllerBlock = createViewController
+    }
+    
+    public var viewController: UIViewController {
+        let viewController = createViewControllerBlock()
+        cacheViewController = viewController
+        return viewController
+    }
+}

--- a/Sources/TabItem.swift
+++ b/Sources/TabItem.swift
@@ -35,7 +35,7 @@ public class LazyTabItem: TabItemProtocol {
     public let createViewControllerBlock: ()->UIViewController
     private(set) public weak var cacheViewController: UIViewController?
     
-    init(title: String, createViewController: @escaping ()->UIViewController) {
+    public init(title: String, createViewController: @escaping ()->UIViewController) {
         self.title = title
         self.createViewControllerBlock = createViewController
     }

--- a/Sources/TabPageOption.swift
+++ b/Sources/TabPageOption.swift
@@ -22,6 +22,8 @@ public struct TabPageOption {
     public var fontSize = UIFont.systemFontSize
     public var currentColor = UIColor(red: 105/255, green: 182/255, blue: 245/255, alpha: 1.0)
     public var defaultColor = UIColor(red: 153/255, green: 153/255, blue: 153/255, alpha: 1.0)
+    public var currentTextColor = UIColor(red: 105/255, green: 182/255, blue: 245/255, alpha: 1.0)
+    public var defaultTextColor = UIColor(red: 153/255, green: 153/255, blue: 153/255, alpha: 1.0)
     public var tabHeight: CGFloat = 32.0
     public var tabMargin: CGFloat = 20.0
     public var tabWidth: CGFloat?

--- a/Sources/TabPageViewController.swift
+++ b/Sources/TabPageViewController.swift
@@ -11,23 +11,17 @@ import UIKit
 open class TabPageViewController: UIPageViewController {
     open var isInfinity: Bool = false
     open var option: TabPageOption = TabPageOption()
-    fileprivate var _tabItems: [TabItemProtocol] = []
-    // For keep compatibility
-    open var tabItems: [(viewController: UIViewController, title: String)] = [] {
-        didSet {
-            self._tabItems = tabItems.map { TabItem(tuple: $0) }
-        }
-    }
+    open var tabItems: [TabItemProtocol] = []
     
     var currentIndex: Int? {
         guard let viewController = viewControllers?.first else {
             return nil
         }
-        return _tabItems.map { $0.cacheViewController }.index { viewController == $0 }
+        return tabItems.map { $0.cacheViewController }.index { viewController == $0 }
     }
     fileprivate var beforeIndex: Int = 0
     fileprivate var tabItemsCount: Int {
-        return _tabItems.count
+        return tabItems.count
     }
     fileprivate var defaultContentOffsetX: CGFloat {
         return self.view.bounds.width
@@ -90,7 +84,7 @@ public extension TabPageViewController {
 
         beforeIndex = index
         shouldScrollCurrentBar = false
-        let nextViewControllers: [UIViewController] = [_tabItems[index].viewController]
+        let nextViewControllers: [UIViewController] = [tabItems[index].viewController]
 
         let completion: ((Bool) -> Void) = { [weak self] _ in
             self?.shouldScrollCurrentBar = true
@@ -108,7 +102,7 @@ public extension TabPageViewController {
     }
     
     public func setTabItems(tabItems: [TabItemProtocol]) {
-        self._tabItems = tabItems
+        self.tabItems = tabItems
         
         setupPageViewController()
         setupScrollView()
@@ -126,7 +120,7 @@ extension TabPageViewController {
         delegate = self
         automaticallyAdjustsScrollViewInsets = false
 
-        setViewControllers([_tabItems[beforeIndex].viewController],
+        setViewControllers([tabItems[beforeIndex].viewController],
                            direction: .forward,
                            animated: false,
                            completion: nil)
@@ -192,7 +186,7 @@ extension TabPageViewController {
 
         view.addConstraints([top, left, right])
 
-        tabView.pageTabItems = _tabItems.map({ $0.title})
+        tabView.pageTabItems = tabItems.map({ $0.title})
         tabView.updateCurrentIndex(beforeIndex, shouldScroll: true)
 
         tabView.pageItemPressedBlock = { [weak self] (index: Int, direction: UIPageViewControllerNavigationDirection) in
@@ -309,7 +303,7 @@ extension TabPageViewController {
 extension TabPageViewController: UIPageViewControllerDataSource {
 
     fileprivate func nextViewController(_ viewController: UIViewController, isAfter: Bool) -> UIViewController? {
-        let currentIndex = self._tabItems.map { $0.cacheViewController }.index { viewController == $0 }
+        let currentIndex = self.tabItems.map { $0.cacheViewController }.index { viewController == $0 }
         guard var index = currentIndex else {
             return nil
         }
@@ -322,14 +316,14 @@ extension TabPageViewController: UIPageViewControllerDataSource {
 
         if isInfinity {
             if index < 0 {
-                index = _tabItems.count - 1
-            } else if index == _tabItems.count {
+                index = tabItems.count - 1
+            } else if index == tabItems.count {
                 index = 0
             }
         }
 
-        if index >= 0 && index < _tabItems.count {
-            return _tabItems[index].viewController
+        if index >= 0 && index < tabItems.count {
+            return tabItems[index].viewController
         }
         return nil
     }

--- a/Sources/TabView.swift
+++ b/Sources/TabView.swift
@@ -90,7 +90,7 @@ internal class TabView: UIView {
         collectionView.scrollsToTop = false
 
         currentBarView.backgroundColor = option.currentColor
-        currentBarViewHeightConstraint.constant = option.currentBarHeight
+        currentBarViewHeightConstraint.constant = option.tabHeight
         if !isInfinity {
             currentBarView.removeFromSuperview()
             collectionView.addSubview(currentBarView)

--- a/Sources/TabView.xib
+++ b/Sources/TabView.xib
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11762" systemVersion="16D32" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -24,6 +24,14 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="80"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pCA-AJ-Zrg">
+                    <rect key="frame" x="110" y="78" width="100" height="2"/>
+                    <color key="backgroundColor" red="0.41176470588235292" green="0.71372549019607845" blue="0.96078431372549022" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="2" id="M76-sL-SLw"/>
+                        <constraint firstAttribute="width" constant="100" id="TzL-4E-b4p"/>
+                    </constraints>
+                </view>
                 <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" alwaysBounceHorizontal="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="Xf0-gn-U1c">
                     <rect key="frame" x="0.0" y="0.0" width="320" height="80"/>
                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
@@ -43,14 +51,6 @@
                     <color key="backgroundColor" red="0.8666666666666667" green="0.8666666666666667" blue="0.8666666666666667" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="1" id="Nhe-bO-iAA"/>
-                    </constraints>
-                </view>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pCA-AJ-Zrg">
-                    <rect key="frame" x="110" y="78" width="100" height="2"/>
-                    <color key="backgroundColor" red="0.41176470588235292" green="0.71372549019607845" blue="0.96078431372549022" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="2" id="M76-sL-SLw"/>
-                        <constraint firstAttribute="width" constant="100" id="TzL-4E-b4p"/>
                     </constraints>
                 </view>
             </subviews>

--- a/TabPageViewController.xcodeproj/project.pbxproj
+++ b/TabPageViewController.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		4C2123001E6EA1FB00572DBD /* TabView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4C2122AF1E6E8AF300572DBD /* TabView.xib */; };
 		4C4753CA1E7159C600D9DD5C /* TabPageViewController.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = OBJ_14 /* TabPageViewController.framework */; };
 		4C4753CB1E7159C600D9DD5C /* TabPageViewController.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = OBJ_14 /* TabPageViewController.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		EFC65FD7204DA7EB00041CA1 /* TabItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFC65FD6204DA7EB00041CA1 /* TabItem.swift */; };
 		F8CE39F71F35AE3A00CF74BA /* LimitedTabPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8CE39F61F35AE3A00CF74BA /* LimitedTabPageViewController.swift */; };
 		F8CE39F91F35AE6500CF74BA /* InfiniteTabPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8CE39F81F35AE6500CF74BA /* InfiniteTabPageViewController.swift */; };
 		OBJ_21 /* TabPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_9 /* TabPageViewController.swift */; };
@@ -72,6 +73,7 @@
 		4C2122EE1E6E8FD300572DBD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = Demo/TabPageViewControllerDemo/Assets.xcassets; sourceTree = "<group>"; };
 		4C2122F21E6E91FA00572DBD /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4C2122F51E6E93DF00572DBD /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Demo/TabPageViewControllerDemo/Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
+		EFC65FD6204DA7EB00041CA1 /* TabItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TabItem.swift; sourceTree = "<group>"; };
 		F8CE39F61F35AE3A00CF74BA /* LimitedTabPageViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LimitedTabPageViewController.swift; path = Demo/TabPageViewControllerDemo/LimitedTabPageViewController.swift; sourceTree = "<group>"; };
 		F8CE39F81F35AE6500CF74BA /* InfiniteTabPageViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = InfiniteTabPageViewController.swift; path = Demo/TabPageViewControllerDemo/InfiniteTabPageViewController.swift; sourceTree = "<group>"; };
 		OBJ_12 /* TabPageViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabPageViewControllerTests.swift; sourceTree = "<group>"; };
@@ -194,6 +196,7 @@
 				OBJ_9 /* TabPageViewController.swift */,
 				4C2122AE1E6E8AF300572DBD /* TabView.swift */,
 				4C2122AF1E6E8AF300572DBD /* TabView.xib */,
+				EFC65FD6204DA7EB00041CA1 /* TabItem.swift */,
 			);
 			name = TabPageViewController;
 			path = Sources;
@@ -335,6 +338,7 @@
 				4C2122B11E6E8AF300572DBD /* TabPageOption.swift in Sources */,
 				OBJ_21 /* TabPageViewController.swift in Sources */,
 				4C2122B21E6E8AF300572DBD /* TabView.swift in Sources */,
+				EFC65FD7204DA7EB00041CA1 /* TabItem.swift in Sources */,
 				4C2122B01E6E8AF300572DBD /* TabCollectionCell.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
If tabItems (TabPageViewController's property) is too many, use many memory.
So, I needs support for lazy initialize of UIViewControllers.

I tried to keep compatibility.
However, I think we lost simplicity....