### PR TITLE
Feature/top tab ajustment

### DIFF
--- a/Sources/TabView.swift
+++ b/Sources/TabView.swift
@@ -214,15 +214,33 @@ extension TabView {
      */
     fileprivate func updateCurrentIndexForTap(_ index: Int) {
         deselectVisibleCells()
-
-        if isInfinity && (index < pageTabItemsCount) || (index >= pageTabItemsCount * 2) {
-            currentIndex = (index < pageTabItemsCount) ? index + pageTabItemsCount : index - pageTabItemsCount
-            shouldScrollToItem = true
-        } else {
+        if isInfinity{
+            let ind = index % pageTabItemsCount
+            currentIndex = pageTabItemsCount + ind
+            let index = IndexPath(row: pageTabItemsCount + ind, section: 0)
+            collectionView.scrollToItem(at: index, at: .centeredHorizontally, animated: false)
+            
+            collectionViewContentOffsetX = collectionView.contentOffset.x
+            currentBarViewWidth = 0.0
+            
+            let firstIndex = IndexPath(row: ind, section: 0)
+            let lastIndex = IndexPath(row: (pageTabItemsCount * 2) + ind, section: 0)
+            if let cell = collectionView.cellForItem(at: firstIndex) as? TabCollectionCell {
+                cell.isCurrent = true
+            }
+            if let cell = collectionView.cellForItem(at: index) as? TabCollectionCell {
+                cell.isCurrent = true
+            }
+            if let cell = collectionView.cellForItem(at: lastIndex) as? TabCollectionCell {
+                cell.isCurrent = true
+            }
+            beforeIndex = currentIndex
+            
+        }else{
             currentIndex = index
+            let indexPath = IndexPath(item: index, section: 0)
+            moveCurrentBarView(indexPath, animated: true, shouldScroll: true)
         }
-        let indexPath = IndexPath(item: index, section: 0)
-        moveCurrentBarView(indexPath, animated: true, shouldScroll: true)
     }
 
     /**

--- a/TabPageViewController.xcodeproj/project.pbxproj
+++ b/TabPageViewController.xcodeproj/project.pbxproj
@@ -266,11 +266,10 @@
 				TargetAttributes = {
 					4C2122CE1E6E8E9700572DBD = {
 						CreatedOnToolsVersion = 8.2.1;
-						DevelopmentTeam = ZX4AV7HKD2;
-						ProvisioningStyle = Automatic;
+						ProvisioningStyle = Manual;
 					};
 					OBJ_16 = {
-						ProvisioningStyle = Automatic;
+						ProvisioningStyle = Manual;
 					};
 				};
 			};
@@ -406,7 +405,8 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = ZX4AV7HKD2;
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
@@ -427,6 +427,7 @@
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = jp.vasily.TabPageViewControllerDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_VERSION = 3.0;
 			};
@@ -456,7 +457,8 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEVELOPMENT_TEAM = ZX4AV7HKD2;
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -473,6 +475,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = jp.vasily.TabPageViewControllerDemo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
 			};
@@ -483,6 +486,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -498,6 +502,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = TabPageViewController;
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				TARGET_NAME = TabPageViewController;
 			};
 			name = Debug;
@@ -507,6 +512,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = (
@@ -522,6 +528,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = TabPageViewController;
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				TARGET_NAME = TabPageViewController;
 			};
 			name = Release;


### PR DESCRIPTION
無限スクロールの上部タップの修正を行いました。
もしよろしければマージしてライブラリに反映して頂けると嬉しいです。

・なおしたこと
上部cellを何度も押すと一回転したり、cell選択部分がずれるところの修正

・行ったこと
タップで移動する処理のところを無限スクロールとそうでないものを分けてまず他のものに影響しないようにしました。

タップした時に移動する場所は今までと同じでcellの数 + indexの値としています。

タブタップ時(無限スクロール)アニメーションをつけるとどうしても真ん中に移動の時に一回転などのような形になってしまうと感じたためアニメーションを無くしました。

本来選択表示されているcellのcurrentをtrueにして色をつけるために3パターン(１段階目のもの、２段階目のもの、3段階目のもの)のcellを探して表示されているもののcurrentをtrueにしました。

上部の方で処理を分けたため同じ関数内での分岐が必要なくなったところもありますが沢山修正してしまうとこんがらがってしまうと思ったため最低限の訂正にしました。

ライブラリとても参考になりました。
ありがとうございます。
